### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,6 +152,7 @@ void* PlayersThread(void* Parameter)
 		}
 		Thread::Wait(100);
 	}
+	delete NetMgr;
 	Thread::Exit();
 	return 0;
 }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V773 The function was exited without releasing the 'NetMgr' pointer. A memory leak is possible. main.cpp 156